### PR TITLE
fix: typo in RHEL examples

### DIFF
--- a/examples/builder/kubevirt-iso/rhel/rhel-iso.yaml
+++ b/examples/builder/kubevirt-iso/rhel/rhel-iso.yaml
@@ -20,4 +20,4 @@ spec:
       - ReadWriteOnce
     resources:
       requests:
-        storage: 3Gi
+        storage: 10Gi

--- a/examples/builder/kubevirt-iso/rhel/rhel.pkr.hcl
+++ b/examples/builder/kubevirt-iso/rhel/rhel.pkr.hcl
@@ -15,7 +15,7 @@ variable "kube_config" {
   default = "${env("KUBECONFIG")}"
 }
 
-source "kubevirt-iso" "fedora" {
+source "kubevirt-iso" "rhel" {
   # Kubernetes configuration
   kube_config   = var.kube_config
   name          = "rhel-10-rand-95"
@@ -53,7 +53,7 @@ source "kubevirt-iso" "fedora" {
 }
 
 build {
-  sources = ["source.kubevirt-iso.fedora"]
+  sources = ["source.kubevirt-iso.rhel"]
 
   provisioner "shell" {
     inline = [


### PR DESCRIPTION
Thanks to Dominik Holler for catching these typos in the RHEL examples.