### PR TITLE
fix: set bus type from VM preference

### DIFF
--- a/builder/kubevirt/iso/config.go
+++ b/builder/kubevirt/iso/config.go
@@ -22,7 +22,9 @@ type Config struct {
 	IsoVolumeName           string        `mapstructure:"iso_volume_name"`
 	DiskSize                string        `mapstructure:"disk_size"`
 	InstanceType            string        `mapstructure:"instance_type"`
+	InstanceTypeKind        string        `mapstructure:"instance_type_kind"`
 	Preference              string        `mapstructure:"preference"`
+	PreferenceKind          string        `mapstructure:"preference_kind"`
 	MediaFiles              []string      `mapstructure:"media_files"`
 	BootCommand             []string      `mapstructure:"boot_command"`
 	BootWait                time.Duration `mapstructure:"boot_wait"`

--- a/builder/kubevirt/iso/config.hcl2spec.go
+++ b/builder/kubevirt/iso/config.hcl2spec.go
@@ -24,7 +24,9 @@ type FlatConfig struct {
 	IsoVolumeName           *string           `mapstructure:"iso_volume_name" cty:"iso_volume_name" hcl:"iso_volume_name"`
 	DiskSize                *string           `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	InstanceType            *string           `mapstructure:"instance_type" cty:"instance_type" hcl:"instance_type"`
+	InstanceTypeKind        *string           `mapstructure:"instance_type_kind" cty:"instance_type_kind" hcl:"instance_type_kind"`
 	Preference              *string           `mapstructure:"preference" cty:"preference" hcl:"preference"`
+	PreferenceKind          *string           `mapstructure:"preference_kind" cty:"preference_kind" hcl:"preference_kind"`
 	MediaFiles              []string          `mapstructure:"media_files" cty:"media_files" hcl:"media_files"`
 	BootCommand             []string          `mapstructure:"boot_command" cty:"boot_command" hcl:"boot_command"`
 	BootWait                *string           `mapstructure:"boot_wait" cty:"boot_wait" hcl:"boot_wait"`
@@ -61,7 +63,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iso_volume_name":            &hcldec.AttrSpec{Name: "iso_volume_name", Type: cty.String, Required: false},
 		"disk_size":                  &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"instance_type":              &hcldec.AttrSpec{Name: "instance_type", Type: cty.String, Required: false},
+		"instance_type_kind":         &hcldec.AttrSpec{Name: "instance_type_kind", Type: cty.String, Required: false},
 		"preference":                 &hcldec.AttrSpec{Name: "preference", Type: cty.String, Required: false},
+		"preference_kind":            &hcldec.AttrSpec{Name: "preference_kind", Type: cty.String, Required: false},
 		"media_files":                &hcldec.AttrSpec{Name: "media_files", Type: cty.List(cty.String), Required: false},
 		"boot_command":               &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
 		"boot_wait":                  &hcldec.AttrSpec{Name: "boot_wait", Type: cty.String, Required: false},

--- a/builder/kubevirt/iso/step_create_virtualmachine.go
+++ b/builder/kubevirt/iso/step_create_virtualmachine.go
@@ -29,8 +29,17 @@ func (s *StepCreateVirtualMachine) Run(ctx context.Context, state multistep.Stat
 	isoVolumeName := s.config.IsoVolumeName
 	diskSize := s.config.DiskSize
 	instanceTypeName := s.config.InstanceType
+	instanceTypeKind := s.config.InstanceTypeKind
 	preferenceName := s.config.Preference
-	virtualMachine := virtualMachine(name, isoVolumeName, diskSize, instanceTypeName, preferenceName)
+	preferenceKind := s.config.PreferenceKind
+	virtualMachine := virtualMachine(
+		name,
+		isoVolumeName,
+		diskSize,
+		instanceTypeName,
+		preferenceName,
+		instanceTypeKind,
+		preferenceKind)
 
 	ui.Sayf("Creating a new temporary VirutalMachine (%s/%s)...", namespace, name)
 

--- a/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
+++ b/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
@@ -12,7 +12,11 @@
 
 - `instance_type` (string) - Instance Type
 
+- `instance_type_kind` (string) - Instance Type Kind
+
 - `preference` (string) - Preference
+
+- `preference_kind` (string) - Preference Kind
 
 - `media_files` ([]string) - Media Files
 

--- a/examples/builder/kubevirt-iso/fedora/fedora.pkr.hcl
+++ b/examples/builder/kubevirt-iso/fedora/fedora.pkr.hcl
@@ -25,9 +25,11 @@ source "kubevirt-iso" "fedora" {
   iso_volume_name = "fedora-42-x86-64-iso"
 
   # VM type and preferences
-  disk_size     = "10Gi"
-  instance_type = "o1.medium"
-  preference    = "linux"
+  disk_size          = "10Gi"
+  instance_type      = "o1.medium"
+  instance_type_kind = "virtualmachineclusterinstancetype" # or "virtualmachineinstancetype"
+  preference         = "linux"
+  preference_kind    = "virtualmachineclusterpreference" # or "virtualmachinepreference"
 
   # Files to include in the ISO installation
   media_files = [

--- a/examples/builder/kubevirt-iso/rhel/rhel.pkr.hcl
+++ b/examples/builder/kubevirt-iso/rhel/rhel.pkr.hcl
@@ -25,9 +25,11 @@ source "kubevirt-iso" "rhel" {
   iso_volume_name = "rhel-10-x86-64-iso"
 
   # VM type and preferences
-  disk_size     = "10Gi"
-  instance_type = "o1.medium"
-  preference    = "rhel.10"
+  disk_size          = "10Gi"
+  instance_type      = "o1.medium"
+  instance_type_kind = "virtualmachineclusterinstancetype" # or "virtualmachineinstancetype"
+  preference         = "rhel.10"
+  preference_kind    = "virtualmachineclusterpreference" # or "virtualmachinepreference"
 
   # Files to include in the ISO installation
   media_files = [


### PR DESCRIPTION
Currently the temporary VM is created with
hardcoded value of bus type, which is virtio,
and is not configurable.

This modification will allow to set the VM's
bus type from the VM preference, and
also an option to choose which kind of the
instance type or preference to use, either
namespaced one or from the cluster.