### PR TITLE
feat: option to keep VM after build

### DIFF
--- a/builder/kubevirt/iso/config.go
+++ b/builder/kubevirt/iso/config.go
@@ -90,6 +90,9 @@ type Config struct {
 	WinRMUsername           string        `mapstructure:"winrm_username"`
 	WinRMPassword           string        `mapstructure:"winrm_password"`
 	WinRMWaitTimeout        time.Duration `mapstructure:"winrm_wait_timeout"`
+
+	// Keep the temporary VM after the build
+	KeepVM bool `mapstructure:"keep_vm"`
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/kubevirt/iso/config.hcl2spec.go
+++ b/builder/kubevirt/iso/config.hcl2spec.go
@@ -46,6 +46,7 @@ type FlatConfig struct {
 	WinRMUsername           *string           `mapstructure:"winrm_username" cty:"winrm_username" hcl:"winrm_username"`
 	WinRMPassword           *string           `mapstructure:"winrm_password" cty:"winrm_password" hcl:"winrm_password"`
 	WinRMWaitTimeout        *string           `mapstructure:"winrm_wait_timeout" cty:"winrm_wait_timeout" hcl:"winrm_wait_timeout"`
+	KeepVM                  *bool             `mapstructure:"keep_vm" cty:"keep_vm" hcl:"keep_vm"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -96,6 +97,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_username":             &hcldec.AttrSpec{Name: "winrm_username", Type: cty.String, Required: false},
 		"winrm_password":             &hcldec.AttrSpec{Name: "winrm_password", Type: cty.String, Required: false},
 		"winrm_wait_timeout":         &hcldec.AttrSpec{Name: "winrm_wait_timeout", Type: cty.String, Required: false},
+		"keep_vm":                    &hcldec.AttrSpec{Name: "keep_vm", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/kubevirt/iso/step_create_virtualmachine.go
+++ b/builder/kubevirt/iso/step_create_virtualmachine.go
@@ -69,6 +69,12 @@ func (s *StepCreateVirtualMachine) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packer.Ui)
 	name := s.config.Name
 	namespace := s.config.Namespace
+	keepVM := s.config.KeepVM
+
+	if keepVM {
+		ui.Sayf("Keeping VirutalMachine (%s/%s).", namespace, name)
+		return
+	}
 
 	ui.Sayf("Deleting VirutalMachine (%s/%s)...", namespace, name)
 

--- a/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
+++ b/docs-partials/builder/kubevirt/iso/Config-not-required.mdx
@@ -56,4 +56,6 @@
 
 - `winrm_wait_timeout` (duration string | ex: "1h5m2s") - Win RM Wait Timeout
 
+- `keep_vm` (bool) - Keep the temporary VM after the build
+
 <!-- End of code generated from the comments of the Config struct in builder/kubevirt/iso/config.go; -->


### PR DESCRIPTION
Allow keeping the temporary VM after a build,
enabling users to perform validation, debugging,
or manual enhancements.