### PR TITLE
fix: resolve golang linter errors

### DIFF
--- a/builder/kubevirt/iso/step_copy_media_files.go
+++ b/builder/kubevirt/iso/step_copy_media_files.go
@@ -47,5 +47,5 @@ func (s *StepCopyMediaFiles) Cleanup(state multistep.StateBag) {
 
 	ui.Sayf("Deleting ConfigMap (%s/%s)...", namespace, name)
 
-	s.client.CoreV1().ConfigMaps(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	_ = s.client.CoreV1().ConfigMaps(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 }

--- a/builder/kubevirt/iso/step_create_virtualmachine.go
+++ b/builder/kubevirt/iso/step_create_virtualmachine.go
@@ -78,7 +78,7 @@ func (s *StepCreateVirtualMachine) Cleanup(state multistep.StateBag) {
 
 	ui.Sayf("Deleting VirtualMachine (%s/%s)...", namespace, name)
 
-	s.client.VirtualMachine(namespace).Delete(context.Background(), name, metav1.DeleteOptions{
+	_ = s.client.VirtualMachine(namespace).Delete(context.Background(), name, metav1.DeleteOptions{
 		GracePeriodSeconds: ptr.To(int64(0)),
 	})
 }


### PR DESCRIPTION
Resolove golang linter errors that were reported from running `golangci-lint` locally.